### PR TITLE
Fix product query transactions

### DIFF
--- a/FastDinner.Api/Controllers/ProductController.cs
+++ b/FastDinner.Api/Controllers/ProductController.cs
@@ -20,7 +20,7 @@ namespace FastDinner.Api.Controllers
         [HttpGet]
         public async Task<IActionResult> Get()
         {
-            var products = await SendCommandAsync<IEnumerable<ProductResponse>>(new ProductQuery());
+            var products = await SendQueryAsync<IEnumerable<ProductResponse>>(new ProductQuery());
 
             return Ok(products);
         }
@@ -28,7 +28,7 @@ namespace FastDinner.Api.Controllers
         [HttpGet("{productId:guid}")]
         public async Task<IActionResult> Get(Guid productId)
         {
-            var products = await SendCommandAsync<ProductResponse>(new ProductQueryById(productId));
+            var products = await SendQueryAsync<ProductResponse>(new ProductQueryById(productId));
 
             return Ok(products);
         }


### PR DESCRIPTION
## Summary
- replace `SendCommandAsync` with `SendQueryAsync` for product listing and search

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565d6efb808322b84db5cd6ddabc42