### PR TITLE
Implement TableQueryById

### DIFF
--- a/FastDinner.Api/Controllers/TableController.cs
+++ b/FastDinner.Api/Controllers/TableController.cs
@@ -20,18 +20,18 @@ namespace FastDinner.Api.Controllers
         [HttpGet]
         public async Task<IActionResult> Get()
         {
-            var products = await SendQueryAsync<IEnumerable<TableResponse>>(new TableQuery());
+            var tables = await SendQueryAsync<IEnumerable<TableResponse>>(new TableQuery());
 
-            return Ok(products);
+            return Ok(tables);
         }
 
         [HttpGet]
         [Route("{id:guid}")]
         public async Task<IActionResult> Get(Guid id)
         {
-            var products = await SendQueryAsync<IEnumerable<TableResponse>>(new TableQuery());
+            var table = await SendQueryAsync<TableResponse>(new TableQueryById(id));
 
-            return Ok(products);
+            return Ok(table);
         }
 
         [HttpPost]

--- a/FastDinner.Application/Handlers/TableQueryHandler.cs
+++ b/FastDinner.Application/Handlers/TableQueryHandler.cs
@@ -6,7 +6,8 @@ using MediatR;
 namespace FastDinner.Application.Handlers
 {
     public class TableQueryHandler :
-        IRequestHandler<TableQuery, IEnumerable<TableResponse>>
+        IRequestHandler<TableQuery, IEnumerable<TableResponse>>,
+        IRequestHandler<TableQueryById, TableResponse>
     {
         private readonly ITableRepository _tableRepository;
 
@@ -20,6 +21,13 @@ namespace FastDinner.Application.Handlers
             var tables = await _tableRepository.GetAllAsync();
 
             return tables.Select(x => new TableResponse(x.Id, x.Description, x.Seats));
+        }
+
+        public async Task<TableResponse> Handle(TableQueryById request, CancellationToken cancellationToken)
+        {
+            var table = await _tableRepository.GetByIdAsync(request.TableId);
+
+            return new TableResponse(table.Id, table.Description, table.Seats);
         }
     }
 }

--- a/FastDinner.Application/Queries/TableQuery.cs
+++ b/FastDinner.Application/Queries/TableQuery.cs
@@ -3,4 +3,5 @@ using MediatR;
 
 namespace FastDinner.Application.Queries;
 
-public record TableQuery: IRequest<IEnumerable<TableResponse>>;
+public record TableQuery : IRequest<IEnumerable<TableResponse>>;
+public record TableQueryById(Guid TableId) : IRequest<TableResponse>;


### PR DESCRIPTION
## Summary
- add `TableQueryById` record
- extend `TableQueryHandler` to handle queries by id
- update Table API controller to return a specific table
- fix variable names in `TableController`

## Testing
- `dotnet build FastDinner.sln -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68565d799d0483228803d09fc0660ccd