### PR TITLE
Fix UnitOfWork transaction action execution

### DIFF
--- a/FastDinner.Infrastructure/Persistence/UnitOfWork.cs
+++ b/FastDinner.Infrastructure/Persistence/UnitOfWork.cs
@@ -24,7 +24,7 @@ public class UnitOfWork : IUnitOfWork
 
     public async Task ExecuteTransaction(Action action)
     {
-        await ExecuteTransaction(() => new Task(action));
+        await ExecuteTransaction(() => Task.Run(action));
     }
 
     public async Task ExecuteTransaction(Func<Task> task)


### PR DESCRIPTION
## Summary
- ensure ExecuteTransaction(Action) actually executes the action

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68565d8f90bc83228f1eae8c279ff49d